### PR TITLE
add Chinese Simplified loc

### DIFF
--- a/Hunty/Localization.cs
+++ b/Hunty/Localization.cs
@@ -9,7 +9,7 @@ namespace Hunty;
 
 public class Localization
 {
-    public static readonly string[] ApplicableLangCodes = { "de", "ja", "fr" };
+    public static readonly string[] ApplicableLangCodes = { "de", "ja", "fr" , "zh"};
     
     private const string FallbackLangCode = "en";
     private readonly string locResourceDirectory = "loc";

--- a/Hunty/loc/zh.json
+++ b/Hunty/loc/zh.json
@@ -1,0 +1,38 @@
+{
+  "Button: Grand Company": {
+    "message": "大国防联军",
+    "description": "MainWindow.Draw"
+  },
+  "Button: Jobs": {
+    "message": "特职",
+    "description": "MainWindow.Draw"
+  },
+  "Error: No Grand Company": {
+    "message": "这个角色尚未加入大国防联军",
+    "description": "MainWindow.Draw"
+  },
+  "Table Label: Monster": {
+    "message": "怪物",
+    "description": "MainWindow.Draw"
+  },
+  "Table Label: Done": {
+    "message": "完成",
+    "description": "MainWindow.Draw"
+  },
+  "Table Label: Dungeon": {
+    "message": "迷宫探险",
+    "description": "MainWindow.Draw"
+  },
+  "Table Label: Coords": {
+    "message": "坐标",
+    "description": "MainWindow.Draw"
+  },
+  "Selector: Rank": {
+    "message": "Rank",
+    "description": "<>c.<Draw>b__18_0"
+  },  
+  "Help Message": {
+    "message": "打开一个小指南",
+    "description": "Plugin..ctor"
+  }
+}


### PR DESCRIPTION
i know it almost useless for all, but i just did (pr it

For monsters' name:
these names cannot be translated to chinese throught current way, beacause chinese resource files only exist on CN server. And there are no resource files in other languages on CN server

PS: i have written a python script to translate S,A,B monsters before, but to be honest, idk player cannot find the monster even they have a coord