### PR TITLE
HuntyXL: Skip done rows - closes #10

### DIFF
--- a/Hunty/Windows/XLWindow.cs
+++ b/Hunty/Windows/XLWindow.cs
@@ -136,6 +136,8 @@ public class XLWindow : Window, IDisposable
 
                 foreach (var monster in monsters)
                 {
+                    var monsterProgress = memoryProgress[monster.Name];
+                    if (monsterProgress.Done) continue;
                     ImGui.TableNextColumn();
                     Helper.DrawIcon(monster.Icon, size);
 
@@ -143,7 +145,6 @@ public class XLWindow : Window, IDisposable
                     ImGui.TextUnformatted(Plugin.GetMonsterNameLoc(monster.Id));
 
                     ImGui.TableNextColumn();
-                    var monsterProgress = memoryProgress[monster.Name];
                     if (monsterProgress.Done)
                     {
                         ImGui.PushFont(UiBuilder.IconFont);


### PR DESCRIPTION
Done rows aren't necessary in and clutter up the /huntyxl view. This change skips displaying Done hunt targets. This greatly improves usability for leveling alt jobs, as the HuntyXL window can be pinned onscreen and made translucent using Dalamud's UI features.