### PR TITLE
Set explicit table column sizing policy

### DIFF
--- a/Hunty/Windows/MainWindow.cs
+++ b/Hunty/Windows/MainWindow.cs
@@ -109,8 +109,8 @@ public class MainWindow : Window, IDisposable
         {
             ImGui.TableSetupColumn("##icon", ImGuiTableColumnFlags.WidthFixed, Helper.IconSize.X * ImGuiHelpers.GlobalScale);
             ImGui.TableSetupColumn(Language.TableLabelMonster);
-            ImGui.TableSetupColumn(Language.TableLabelDone, ImGuiTableColumnFlags.None, 0.4f);
-            ImGui.TableSetupColumn(monsters[0].IsOpenWorld ? Language.TableLabelCoords : Language.TableLabelDungeon, ImGuiTableColumnFlags.None, 1.5f);
+            ImGui.TableSetupColumn(Language.TableLabelDone, ImGuiTableColumnFlags.WidthStretch, 0.4f);
+            ImGui.TableSetupColumn(monsters[0].IsOpenWorld ? Language.TableLabelCoords : Language.TableLabelDungeon, ImGuiTableColumnFlags.WidthStretch, 1.5f);
 
             ImGui.TableHeadersRow();
             foreach (var monster in monsters)


### PR DESCRIPTION
When using the default table and column sizing policy, ImGui [will assert if you pass in an init_width_or_weight](https://github.com/goatcorp/gc-imgui/blob/eb406ca9f664b009b8d446b41aa0979b69d4ec30/imgui_tables.cpp#L1425-L1428) to prevent you from mixing up width and weights.

Setting the column sizing policy explicitly to `WidthStretch` makes it more explicit that this is a weight, and doesn't change the behaviour.